### PR TITLE
Add keyboardShouldPersistTaps to ScrollView

### DIFF
--- a/examples/scrollable-search.tsx
+++ b/examples/scrollable-search.tsx
@@ -128,6 +128,7 @@ const Content = ({ fontLoaded }: { fontLoaded: boolean }) => {
             <ScrollView
               style={styles.focusedScroll}
               showsVerticalScrollIndicator={false}
+              keyboardShouldPersistTaps="handled"
             >
               <View style={styles.focusedSection}>
                 <View style={styles.focusedHeader}>


### PR DESCRIPTION
Users will be able to interact with UI elements (buttons, search results, etc.) while the keyboard is visible in the search screen.