### PR TITLE
Fix BentoGrid mobile layout responsiveness

### DIFF
--- a/docs/components/ui/bento-grid.tsx
+++ b/docs/components/ui/bento-grid.tsx
@@ -43,7 +43,7 @@ const BentoGridItem = ({
       onClick={() => router.push("/why-reacticx")}
       variants={variants}
       className={cn(
-        "group border-white/10 bg-neutral-950 hover:border-white/20 relative flex h-full cursor-pointer flex-col justify-between overflow-hidden rounded-xl border px-6 pt-6 pb-10 shadow-md transition-all duration-500",
+        "group border-white/10 bg-neutral-950 hover:border-white/20 relative flex h-full cursor-pointer flex-col justify-between overflow-hidden rounded-xl border px-6 pt-6 pb-10 shadow-md transition-all duration-500 col-span-4",
         className,
       )}
     >
@@ -146,10 +146,10 @@ export default function BentoGrid1() {
             size={item.size}
             className={cn(
               item.size === "large"
-                ? "col-span-4"
+                ? "md:col-span-4"
                 : item.size === "medium"
-                  ? "col-span-3"
-                  : "col-span-2",
+                  ? "md:col-span-3"
+                  : "md:col-span-2",
               "h-full",
             )}
           />

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -4,7 +4,7 @@ description: Getting started with Reacticx
 icon: ListStart
 ---
 
-<div className="flex ml-3 my-10">
+<div className="flex my-10">
   <img
     src="/static/deps/getting-started-poster-dark.png"
     alt="Reacticx Getting Started"


### PR DESCRIPTION
Resolves the BentoGrid item layout issue on mobile devices.

Previously, items used fixed `col-span` values across all breakpoints, which caused stacked cards to render with reduced width on smaller screens.

This change scopes the `col-span` values to the `md` breakpoint, allowing cards to use the full width on mobile while preserving the intended desktop layout.

Additionally, removes an unnecessary `ml-3` margin from the image container to keep alignment consistent with other pages.


## Before 

### BentoGrid mobile layout
<img width="389" height="649" alt="bento mobile before" src="https://github.com/user-attachments/assets/d72024a2-60fa-45fc-891f-0babb5256588" />


### Image alignment
<img width="472" height="662" alt="image alignment before" src="https://github.com/user-attachments/assets/9c60718e-14d8-41df-8909-1dd7470cb809" />



## After 

### BentoGrid mobile layout
<img width="385" height="647" alt="bento mobile after" src="https://github.com/user-attachments/assets/e421367c-d714-4b53-9e28-cc42885ddb74" />


### Image alignment

<img width="412" height="651" alt="image alignment after" src="https://github.com/user-attachments/assets/b490d6e4-7e09-4f13-9094-cf847c1012aa" />
