### PR TITLE
fix: search bar jumping on input

### DIFF
--- a/src/components/molecules/search-bar/SearchBar.tsx
+++ b/src/components/molecules/search-bar/SearchBar.tsx
@@ -388,7 +388,7 @@ const styles = StyleSheet.create({
 
     textAlign: "left",
   },
-  clearButtonNew: {
+  clearButton: {
     paddingVertical: 2,
     paddingHorizontal: 4,
     marginLeft: 4,


### PR DESCRIPTION
With the default sizing, the search bar height jumps after typing in a character due to the clear button appearing and it's height + padding being larger than the search bar
To prevent this the vertical padding of the button has been reduced

Before v. After

https://github.com/user-attachments/assets/495ca1bc-04df-425f-ae8d-53988f935340

