### PR TITLE
fix: serve markdown for copy markdown button

### DIFF
--- a/docs/app/llms.mdx/[[...slug]]/route.ts
+++ b/docs/app/llms.mdx/[[...slug]]/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server";
+import { notFound } from "next/navigation";
+import { source } from "@/lib/source";
+import { getLLMText } from "@/lib/get-llm-text";
+
+interface RouteContext {
+  params: Promise<{ slug?: string[] }>;
+}
+
+export async function GET(_req: NextRequest, { params }: RouteContext) {
+  const slug = (await params).slug;
+  const page = source.getPage(slug);
+
+  if (!page) {
+    notFound();
+  }
+
+  return new NextResponse(await getLLMText(page), {
+    headers: {
+      "Content-Type": "text/markdown",
+    },
+  });
+}
+
+export async function generateStaticParams() {
+  return source.generateParams();
+}

--- a/docs/lib/get-llm-text.ts
+++ b/docs/lib/get-llm-text.ts
@@ -1,0 +1,19 @@
+import { type Page } from "@/lib/source";
+
+export async function getLLMText(page: Page): Promise<string> {
+  const section = page.slugs[0];
+  const category =
+    {
+      components: "Reacticx Components",
+    }[section] ?? "Reacticx Documentation";
+
+  const processed = await page.data.getText("processed");
+
+  return `# ${category}: ${page.data.title}
+URL: https://www.reacticx.com${page.url}
+Source: https://raw.githubusercontent.com/rit3zh/reacticx/main/docs/content/docs/${page.path}
+
+${page.data.description ?? ""}
+
+${processed}`;
+}

--- a/docs/lib/source.ts
+++ b/docs/lib/source.ts
@@ -1,4 +1,4 @@
-import { loader } from "fumadocs-core/source";
+import { loader, type InferPageType } from "fumadocs-core/source";
 import { icons } from "lucide-react";
 import { createElement } from "react";
 import { docs } from "@/.source";
@@ -16,3 +16,5 @@ export const source = loader({
     }
   },
 });
+
+export type Page = InferPageType<typeof source>;

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -57,6 +57,14 @@ const nextConfig = {
       },
     ];
   },
+  async rewrites() {
+    return [
+      {
+        source: "/docs/:path*.mdx",
+        destination: "/llms.mdx/:path*",
+      },
+    ];
+  },
   images: {
     remotePatterns: [
       {

--- a/docs/source.config.ts
+++ b/docs/source.config.ts
@@ -15,6 +15,9 @@ export const docs = defineDocs({
         .transform((val) => (val ? new Date(val) : undefined))
         .optional(),
     }),
+    postprocess: {
+      includeProcessedMarkdown: true,
+    },
   },
 });
 


### PR DESCRIPTION
Fixes an issue where the “Copy Markdown” button copied an HTML error page instead of markdown.

The .mdx URL being fetched wasn’t resolving to a markdown route, so a 404 HTML page was returned. This change ensures .mdx URLs resolve correctly and return markdown content.

This implementation is inspired by the Fumadocs LLM integration guide:
https://github.com/fuma-nama/fumadocs/blob/dev/apps/docs/content/docs/(framework)/integrations/llms.mdx#mdx-mdx-extension



### Example

The button now copies markdown content like:

```md
# Reacticx Components: Aurora
URL: https://www.reacticx.com/docs/components/aurora
Source: https://raw.githubusercontent.com/rit3zh/reacticx/main/docs/content/docs/components/aurora.mdx

A Skia-based animated aurora effect that renders flowing light waves over a soft sky gradient
…
```

Fixes: https://github.com/rit3zh/reacticx/issues/22