### PR TITLE
Fix JS thread hanging when resuming app

### DIFF
--- a/src/components/organisms/apple-intelligence/index.tsx
+++ b/src/components/organisms/apple-intelligence/index.tsx
@@ -46,14 +46,12 @@ export const SiriProvider: React.FC<IAppleIntelligenceProvider> &
       height: 0,
     });
     const busyRef = useRef<boolean>(false);
-    const startTimeRef = useRef<number>(0);
-    const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
     const [overlayContent, setOverlayContent] = useState<React.ReactNode>(null);
 
     const overlayOpacity = useSharedValue<number>(0);
 
-    const { iTime, intensity, uniforms, applyConfig } = useSiriUniforms({
+    const { iTime, intensity, uniforms, applyConfig, frameCallback } = useSiriUniforms({
       layout,
       defaultWave,
       defaultNoise,
@@ -68,27 +66,13 @@ export const SiriProvider: React.FC<IAppleIntelligenceProvider> &
       opacity: overlayOpacity.value,
     }));
 
-    const stopClock = useCallback(() => {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
-      }
-    }, []);
-
     const dismiss = useCallback(() => {
-      stopClock();
+      frameCallback.setActive(false);
       busyRef.current = false;
       setActive(false);
       setSnapshot(null);
       setOverlayContent(null);
-    }, [stopClock]);
-
-    const startClock = useCallback(() => {
-      startTimeRef.current = Date.now();
-      intervalRef.current = setInterval(() => {
-        iTime.value = (Date.now() - startTimeRef.current) / 1000;
-      }, 16);
-    }, [iTime]);
+    }, [frameCallback]);
 
     const toggle = useCallback(
       async (options?: ISiriToggleOptions) => {
@@ -135,7 +119,7 @@ export const SiriProvider: React.FC<IAppleIntelligenceProvider> &
 
           setSnapshot(image);
           setActive(true);
-          startClock();
+          frameCallback.setActive(true);
           busyRef.current = false;
 
           intensity.value = withTiming(1, {
@@ -153,7 +137,7 @@ export const SiriProvider: React.FC<IAppleIntelligenceProvider> &
         introDuration,
         outroDuration,
         applyConfig,
-        startClock,
+        frameCallback,
         dismiss,
         intensity,
         overlayOpacity,

--- a/src/components/organisms/apple-intelligence/types.ts
+++ b/src/components/organisms/apple-intelligence/types.ts
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import type { DerivedValue, SharedValue } from "react-native-reanimated";
+import type { DerivedValue, SharedValue, FrameCallback } from "react-native-reanimated";
 
 interface IAppleIntelligenceProvider {
   children: ReactNode;
@@ -118,6 +118,7 @@ interface IUseSiriUniformsResult {
   intensity: SharedValue<number>;
   uniforms: DerivedValue<IShaderUniforms>;
   applyConfig: (override?: ISiriToggleOptions) => void;
+  frameCallback: FrameCallback;
 }
 
 export type {

--- a/src/components/organisms/apple-intelligence/use-siri-uniforms.ts
+++ b/src/components/organisms/apple-intelligence/use-siri-uniforms.ts
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import { useSharedValue, useDerivedValue } from "react-native-reanimated";
+import { useSharedValue, useDerivedValue, useFrameCallback } from "react-native-reanimated";
 import type {
   ISiriToggleOptions,
   IUseSiriUniformsOptions,
@@ -27,6 +27,10 @@ function useSiriUniforms<T extends IUseSiriUniformsOptions>({
 }: T): IUseSiriUniformsResult {
   const iTime = useSharedValue<number>(0);
   const intensity = useSharedValue<number>(0);
+
+  const frameCallback = useFrameCallback((frameInfo) => {
+    iTime.value = frameInfo.timeSinceFirstFrame / 1000;
+  }, false);
 
   const uMargin = useSharedValue<number>(DEFAULT_BORDER.margin);
   const uExcess = useSharedValue<number>(DEFAULT_BORDER.spread);
@@ -173,6 +177,6 @@ function useSiriUniforms<T extends IUseSiriUniformsOptions>({
     ],
   );
 
-  return { iTime, intensity, uniforms, applyConfig };
+  return { iTime, intensity, uniforms, applyConfig, frameCallback };
 }
 export { useSiriUniforms };

--- a/website/react-native/apple-intelligence.tsx
+++ b/website/react-native/apple-intelligence.tsx
@@ -46,14 +46,12 @@ export const SiriProvider: React.FC<IAppleIntelligenceProvider> &
       height: 0,
     });
     const busyRef = useRef<boolean>(false);
-    const startTimeRef = useRef<number>(0);
-    const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
     const [overlayContent, setOverlayContent] = useState<React.ReactNode>(null);
 
     const overlayOpacity = useSharedValue<number>(0);
 
-    const { iTime, intensity, uniforms, applyConfig } = useSiriUniforms({
+    const { iTime, intensity, uniforms, applyConfig, frameCallback } = useSiriUniforms({
       layout,
       defaultWave,
       defaultNoise,
@@ -68,27 +66,13 @@ export const SiriProvider: React.FC<IAppleIntelligenceProvider> &
       opacity: overlayOpacity.value,
     }));
 
-    const stopClock = useCallback(() => {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
-      }
-    }, []);
-
     const dismiss = useCallback(() => {
-      stopClock();
+      frameCallback.setActive(false);
       busyRef.current = false;
       setActive(false);
       setSnapshot(null);
       setOverlayContent(null);
-    }, [stopClock]);
-
-    const startClock = useCallback(() => {
-      startTimeRef.current = Date.now();
-      intervalRef.current = setInterval(() => {
-        iTime.value = (Date.now() - startTimeRef.current) / 1000;
-      }, 16);
-    }, [iTime]);
+    }, [frameCallback]);
 
     const toggle = useCallback(
       async (options?: ISiriToggleOptions) => {
@@ -135,7 +119,7 @@ export const SiriProvider: React.FC<IAppleIntelligenceProvider> &
 
           setSnapshot(image);
           setActive(true);
-          startClock();
+          frameCallback.setActive(true);
           busyRef.current = false;
 
           intensity.value = withTiming(1, {
@@ -153,7 +137,7 @@ export const SiriProvider: React.FC<IAppleIntelligenceProvider> &
         introDuration,
         outroDuration,
         applyConfig,
-        startClock,
+        frameCallback,
         dismiss,
         intensity,
         overlayOpacity,


### PR DESCRIPTION
At first I thought this was an issue with Skia:
https://github.com/Shopify/react-native-skia/issues/3818

However, after some digging I found out that the Apple Intelligence component used a `setInterval(..., 16)` on the JS thread to update its shader's time uniform at ~60fps, but this interval was never paused when the app was backgrounded. As a result, timer callbacks queued up while the JS thread was suspended, and on resume they all fired back-to-back, flooding the Reanimated and Skia pipelines with thousands of redundant shared value writes and shader redraws that blocked the JS thread.

The fix was to replace `setInterval` with Reanimated's `useFrameCallback`, which runs on the UI thread via native `requestAnimationFrame` and naturally stops when the app is backgrounded.
