### PR TITLE
fix(cli): assert on an import the registry still cannot resolve

### DIFF
--- a/reacticx-cli/test/smoke.mjs
+++ b/reacticx-cli/test/smoke.mjs
@@ -259,7 +259,11 @@ await test("unresolvable imports are reported", () => {
   project(BASE);
   const out = cli(["add", "sign-up-v1", "--yes", "--dry"]);
   contains(out, "unresolved", "the unresolved section is missing");
-  contains(out, "@/helpers/hooks/use-responsive", "the dangling import was not named");
+  // Font assets, not a hook: the registry serves source files, so `sign-up-v1`'s
+  // `@/assets/fonts/*.ttf` imports can never resolve. `@/helpers/hooks/use-responsive`
+  // used to stand in here, but it is published now and resolves as a shared
+  // dependency, which quietly turned this assertion into a false failure.
+  contains(out, "@/assets/fonts/", "the dangling import was not named");
 });
 
 await test("missing npm packages are found but not installed", () => {


### PR DESCRIPTION
### Problem

`bun run test` fails on `main`:

```
  ✗ unresolvable imports are reported
    the dangling import was not named
      expected to find: @/helpers/hooks/use-responsive

  1 failed, 34 passed
```

The test asserts that `@/helpers/hooks/use-responsive` shows up in the unresolved section of `reacticx add sign-up-v1 --dry`. That is no longer true, and the CLI is right — the hook has been published since the test was written. The bucket index now carries:

```
shared/hooks/use-responsive/index.ts
shared/hooks/use-responsive/types.ts
```

so `SHARED_PREFIXES` maps `@/helpers/hooks/` → `shared/hooks/` and the import resolves. Current output:

```
  use-responsive  shared · required by sign-up-v1
    src/shared/hooks/use-responsive/index.ts
    src/shared/hooks/use-responsive/types.ts

  unresolved ──────────────────────────────────────────

  ! @/assets/fonts/sf-pro-rounded.ttf · sign-up-v1
  ! @/assets/fonts/HelveticaNowDisplayMedium.ttf · sign-up-v1
```

The test was pinned to a gap in the registry, so publishing the hook turned a green test red.

### Fix

Assert on the `@/assets/fonts/` imports instead. `sign-up-v1` loads two `.ttf` files through `useFonts`, and the registry serves source files, not binary assets — so those stay unresolvable by design rather than by omission. Matching the directory rather than a filename keeps the assertion stable if a font is ever renamed.

### Testing

```
bun run build && bun run test
  35 passed
```

Before the change, on `main`: `1 failed, 34 passed`.